### PR TITLE
Small fixes to Windows server and Arduino client

### DIFF
--- a/AY3910RegWrite/AY3910RegWrite.ino
+++ b/AY3910RegWrite/AY3910RegWrite.ino
@@ -101,7 +101,7 @@ void setup_control()
 
 void set_control(int mode)
 {
-  PORTC = (PORTC & 111111100) | (mode);
+  PORTC = (PORTC & B11111100) | (mode);
 }
 
 void SetData(unsigned char data)

--- a/mym2serial_win32.c
+++ b/mym2serial_win32.c
@@ -113,7 +113,7 @@ int main(int argc,char *argv[])
 	Status = GetCommState(hComPort, &dcbSerialParams);
 	
 	// set state
-	dcbSerialParams.BaudRate = CBR_9600;  // Setting BaudRate = 9600
+	dcbSerialParams.BaudRate = CBR_115200;// Setting BaudRate = 115200
 	dcbSerialParams.ByteSize = 8;         // Setting ByteSize = 8
 	dcbSerialParams.StopBits = ONESTOPBIT;// Setting StopBits = 1
 	dcbSerialParams.Parity   = NOPARITY;  // Setting Parity = None


### PR DESCRIPTION
This corrects the baud rate of the Windows port of the MYM server to match the Arduino client. Without the change the client sees zeroes from the server data stream causing the AY-3-8910 to make no sound at all. The connection now works but playback is quite slow and jerky. I have not tried the *nix server to compare.

This also corrects the PORTC control bit setting code with a mask of the correct type. This fixes continuous audio glitches.

EDIT:

I think the laggy server streaming has a lot to do with my ancient laptop. Other processes impact its precision and moving the console window into the background improves things.